### PR TITLE
Add Create Users GitHub Actions workflow

### DIFF
--- a/.github/workflows/create-users.yml
+++ b/.github/workflows/create-users.yml
@@ -1,0 +1,44 @@
+name: Create Users
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_bu_mid:
+        description: "Business Unit MID the users should be created in"
+        required: true
+        type: string
+      user_list:
+        description: "One user per line: username,Full Name (tab or comma separated — paste two columns straight from a spreadsheet)"
+        required: true
+        type: string
+
+jobs:
+  create-users:
+    runs-on: ubuntu-latest
+    environment: sfmc-production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Create Users automation
+        env:
+          SFMC_SUBDOMAIN: ${{ secrets.SFMC_SUBDOMAIN }}
+          SFMC_CLIENT_ID: ${{ secrets.SFMC_CLIENT_ID }}
+          SFMC_CLIENT_SECRET: ${{ secrets.SFMC_CLIENT_SECRET }}
+          DEFAULT_USER_PASSWORD: ${{ secrets.DEFAULT_USER_PASSWORD }}
+          SFMC_PARENT_MID: ${{ vars.SFMC_PARENT_MID }}
+          DEFAULT_USER_ROLE_ID: ${{ vars.DEFAULT_USER_ROLE_ID }}
+          DEFAULT_USER_EMAIL: ${{ vars.DEFAULT_USER_EMAIL }}
+          LOG_DE_KEY: ${{ vars.LOG_DE_KEY_CREATE_USERS }}
+          TARGET_BU_MID: ${{ inputs.target_bu_mid }}
+          USER_LIST: ${{ inputs.user_list }}
+        run: npm run create-users

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+# MKTVIW Setup — GitHub Actions
+
+This repo has two independent workflows that together recreate the old
+CloudPage/Data Extension automations as GitHub Actions:
+
+1. **Create Business Unit** — see below.
+2. **Create Users** — see [Create Users — GitHub Actions](#create-users--github-actions)
+   further down.
+
+---
+
 # Create Business Unit — GitHub Actions
 
 Recreates the old CloudPage automation (`1.1 Create Business Unit`, `1.2 Update
@@ -124,3 +135,111 @@ don't want this gate, delete the `environment:` line from the workflow file.
   step before `Run Business Unit automation` that calls the Claude API and
   feeds its structured output into `env:` — the core SFMC logic in
   `scripts/run.js` doesn't need to change.
+
+---
+
+# Create Users — GitHub Actions
+
+Recreates the old CloudPage automation (`2.1 Create Student Users`, `2.2
+Update Student Users`) as a single GitHub Actions workflow. A team member
+provides the target Business Unit MID and a list of usernames via the **Run
+workflow** form — no CloudPage, no Data Extension trigger row, no SSJS.
+
+## How it works
+
+1. `.github/workflows/create-users.yml` defines a `workflow_dispatch`
+   trigger with two inputs: `target_bu_mid` (the MID to create the users
+   in) and `user_list` (a multi-line textarea — see format below).
+2. The job runs `scripts/create-users.js`, which:
+   - Authenticates to SFMC via REST OAuth (`client_credentials`).
+   - Parses `user_list` into individual users.
+   - For each user, calls SOAP `Create` on `AccountUser` (mirrors `2.1`),
+     using the hardcoded default password, role, and email, and assigning
+     the user to `target_bu_mid`.
+   - **Then** calls a separate SOAP `Update` on that same `AccountUser`
+     setting `MustChangePassword` to `false` (mirrors `2.2`). This has to
+     be a second, separate call — SFMC's `Create` does not reliably honor
+     `MustChangePassword: false` at creation time, which is exactly why the
+     original CloudPage automation was split into two scripts/two
+     automation steps in the first place.
+   - Logs each step to the `Automation_Log_CreateVIWStudent` Data
+     Extension (same DE the old scripts logged to), via the SOAP
+     `DataExtensionObject` write path.
+   - Writes a human-readable progress table to the GitHub Actions job
+     summary.
+
+Everything **except** the target BU MID and the usernames/names is
+hardcoded as repo Secrets/Variables — password, role, and email are fixed
+per org, matching the request that the team only ever has to supply "which
+BU" and "which usernames."
+
+## One-time setup
+
+### 1. Add Secrets (Settings → Secrets and variables → Actions → **Secrets**)
+
+Never paste these into a chat/AI tool — enter them directly in GitHub's UI.
+
+| Secret | Description |
+|---|---|
+| `SFMC_SUBDOMAIN` | Same tenant subdomain used by the Create Business Unit workflow (shared secret, not duplicated per workflow). |
+| `SFMC_CLIENT_ID` | Installed Package Client ID (shared with Create Business Unit; needs SOAP AccountUser create/update permissions). |
+| `SFMC_CLIENT_SECRET` | Installed Package Client Secret. |
+| `DEFAULT_USER_PASSWORD` | The fixed password every new user is created with. Stored as a Secret (not a plain Variable) precisely so it's never shown in the workflow form, never printed to logs, and never committed to the repo — while still being "hardcoded" in the sense that the team never types or sees it per run. |
+
+### 2. Add Variables (Settings → Secrets and variables → Actions → **Variables**)
+
+**⚠️ All example values below are placeholders only — fill in this org's own
+values.**
+
+| Variable | Example (placeholder) | Notes |
+|---|---|---|
+| `SFMC_PARENT_MID` | `000000000` | Same enterprise parent MID used for API auth context as the Create Business Unit workflow. |
+| `DEFAULT_USER_ROLE_ID` | `d2be5e3f-4a43-f011-a5d5-5cba2c6ff268` | The Role ObjectID every new user is assigned (matches `config.roleID` in the original `2.1`/`2.2` scripts). |
+| `DEFAULT_USER_EMAIL` | `viw-students@yourcompany.com` | The single fixed email/notification address used for every created user (per this org's stated setup, all users share one email). |
+| `LOG_DE_KEY_CREATE_USERS` | `Automation_Log_CreateVIWStudent` | ExternalKey of the log DE in *this* org (create one with columns `Username`, `Status`, `Message`, `LogDate` if it doesn't exist yet). Kept as a separate Variable name from the BU workflow's `LOG_DE_KEY` so the two workflows can log to different DEs without colliding. |
+
+### 3. (Optional but recommended) Require approval before running
+
+Same `sfmc-production` GitHub Environment as the Create Business Unit
+workflow — add required reviewers under Settings → Environments if you
+want a human approval gate before the job calls SFMC. Delete the
+`environment:` line from `create-users.yml` if you don't want this gate.
+
+## Running it
+
+1. Go to the **Actions** tab → **Create Users** → **Run workflow**.
+2. Enter the target **Business Unit MID**.
+3. Paste the user list into the textarea — **one user per line**, as
+   `username,Full Name` (comma or tab separated, so you can paste two
+   columns straight out of a spreadsheet without reformatting). For
+   example:
+
+   ```
+   jsmith@school.edu	Jane Smith
+   bwong@school.edu	Bob Wong
+   ```
+
+4. Click **Run workflow** and watch the job summary for a per-user
+   status table (Create result + password-never-expire Update result).
+
+## Differences from the old CloudPage solution
+
+- **No Data Extension trigger row required.** The old flow required
+  loading `Student_Details_DE` and running an automation against it. Here,
+  the BU MID and user list are direct form inputs.
+- **The required two-call sequence (Create, then Update
+  `MustChangePassword`) is preserved exactly**, including the reason for
+  it — it's implemented as two SOAP calls per user inside one script run,
+  rather than two separate automations/scripts, but the underlying API
+  behavior it works around is unchanged.
+- **Credentials never touch AI tooling.** Enter secrets directly into
+  GitHub's Secrets UI; nothing sensitive is passed through chat or
+  committed to the repo.
+
+## Extending later
+
+- If a future request needs a genuinely different email/name per user
+  instead of the one shared email, add a third column to the `user_list`
+  format (e.g. `username,Full Name,email`) and thread it through
+  `parseUserList()` and `createUser()` in `scripts/create-users.js` —
+  no other structural change needed.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "Creates a new SFMC Business Unit, configures its unsubscribe settings, and assigns admin users — driven by a GitHub Actions workflow_dispatch form.",
   "type": "commonjs",
   "scripts": {
-    "create-bu": "node scripts/run.js"
+    "create-bu": "node scripts/run.js",
+    "create-users": "node scripts/create-users.js"
   },
   "dependencies": {
     "axios": "^1.7.7",

--- a/scripts/create-users.js
+++ b/scripts/create-users.js
@@ -1,0 +1,170 @@
+"use strict";
+
+/**
+ * Recreates the 2-step CloudPage automation ("2.1 Create Student Users" ->
+ * "2.2 Update Student Users") as a single GitHub Actions job.
+ *
+ * The two-call sequence (Create, then a separate Update) is required
+ * because SFMC's AccountUser Create call does not reliably honor
+ * MustChangePassword=false on creation -- it has to be set again via a
+ * follow-up Update call per user. See sfmc-client.js createUser() and
+ * updateUserMustChangePasswordFalse().
+ *
+ * Inputs come from workflow_dispatch (see .github/workflows/create-users.yml)
+ * mapped to env vars by the workflow. Org-level config (password, role,
+ * email, parent MID) comes from repo Secrets/Variables; the per-run BU MID
+ * and user list come from the workflow form.
+ */
+
+const fs = require("fs");
+const { SfmcClient } = require("./sfmc-client");
+
+function requireEnv(name) {
+  const v = process.env[name];
+  if (!v) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return v;
+}
+
+function summaryLine(line) {
+  console.log(line);
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (summaryPath) {
+    fs.appendFileSync(summaryPath, line + "\n");
+  }
+}
+
+/**
+ * Parses the multi-line "username,Full Name" (or tab-separated) textarea
+ * input into { userId, name } objects. One user per line. Blank lines and
+ * a header row (if someone pastes "username,name") are skipped.
+ */
+function parseUserList(raw) {
+  return raw
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const parts = line.split(/\t|,/).map((p) => p.trim());
+      return { userId: parts[0] || "", name: parts[1] || "" };
+    })
+    .filter((u) => u.userId && u.userId.toLowerCase() !== "username");
+}
+
+async function main() {
+  // --- Secrets (never printed) ---
+  const subdomain = requireEnv("SFMC_SUBDOMAIN");
+  const clientId = requireEnv("SFMC_CLIENT_ID");
+  const clientSecret = requireEnv("SFMC_CLIENT_SECRET");
+  const defaultPassword = requireEnv("DEFAULT_USER_PASSWORD");
+
+  // --- Org-level config (repo Variables, fixed) ---
+  const authMID = requireEnv("SFMC_PARENT_MID");
+  const roleID = requireEnv("DEFAULT_USER_ROLE_ID");
+  const userEmail = requireEnv("DEFAULT_USER_EMAIL");
+  const logDeKey = process.env.LOG_DE_KEY || "Automation_Log_CreateVIWStudent";
+
+  // --- Per-request inputs (from the workflow_dispatch form) ---
+  const targetMID = requireEnv("TARGET_BU_MID").trim();
+  const userListRaw = requireEnv("USER_LIST");
+  const users = parseUserList(userListRaw);
+
+  if (users.length === 0) {
+    throw new Error("No users parsed from the user list input. Expected one 'username,Full Name' pair per line.");
+  }
+
+  summaryLine(`## Create Users in BU ${targetMID}`);
+  summaryLine("");
+  summaryLine(`Users to create: ${users.length}`);
+  summaryLine("");
+
+  const client = new SfmcClient({ subdomain, clientId, clientSecret, accountId: authMID });
+  await client.authenticate();
+
+  const log = async (username, status, message) => {
+    try {
+      await client.logRow(logDeKey, {
+        Username: username,
+        Status: status,
+        Message: message,
+        LogDate: new Date().toISOString(),
+      });
+    } catch (err) {
+      summaryLine(`> ⚠️ Logging to ${logDeKey} failed: ${err.message}`);
+    }
+  };
+
+  summaryLine("| Username | Name | Create | Set password never-expire |");
+  summaryLine("|---|---|---|---|");
+
+  let anyFailed = false;
+
+  for (const user of users) {
+    let createMark = "";
+    let updateMark = "";
+
+    try {
+      const createResult = await client.createUser({
+        userId: user.userId,
+        password: defaultPassword,
+        name: user.name || user.userId,
+        email: userEmail,
+        authMID,
+        targetMID,
+        roleID,
+      });
+
+      if (!createResult.ok) {
+        createMark = `❌ ${createResult.statusMessage}`;
+        updateMark = "skipped";
+        anyFailed = true;
+        await log(user.userId, "Failed: Create", createResult.statusMessage);
+        summaryLine(`| ${user.userId} | ${user.name} | ${createMark} | ${updateMark} |`);
+        continue;
+      }
+
+      createMark = "✅ OK";
+      await log(user.userId, "Created", "AccountUser created");
+
+      // --- Second call: required so the user isn't forced to change the
+      // password again on next login (see file header for why this can't
+      // be combined into the Create call above). ---
+      const updateResult = await client.updateUserMustChangePasswordFalse({
+        userId: user.userId,
+        authMID,
+      });
+
+      if (!updateResult.ok) {
+        updateMark = `❌ ${updateResult.statusMessage}`;
+        anyFailed = true;
+        await log(user.userId, "Failed: Update", updateResult.statusMessage);
+      } else {
+        updateMark = "✅ OK";
+        await log(user.userId, "Complete", "Password never-expire set");
+      }
+    } catch (err) {
+      anyFailed = true;
+      createMark = createMark || `❌ ${err.message}`;
+      updateMark = updateMark || "❌ exception";
+      await log(user.userId, "Failed: Exception", err.message);
+    }
+
+    summaryLine(`| ${user.userId} | ${user.name} | ${createMark} | ${updateMark} |`);
+  }
+
+  summaryLine("");
+  if (anyFailed) {
+    summaryLine("### ⚠️ Completed with errors — see table above.");
+    process.exitCode = 1;
+    return;
+  }
+
+  summaryLine("### ✅ User creation automation complete.");
+}
+
+main().catch((err) => {
+  summaryLine(`### ❌ Script exception: ${err.message}`);
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/scripts/sfmc-client.js
+++ b/scripts/sfmc-client.js
@@ -203,6 +203,60 @@ class SfmcClient {
     return parseCreateOrUpdateResult(raw);
   }
 
+  /**
+   * Create an AccountUser (SFMC Marketing Cloud user). Mirrors
+   * "2.1 Create Student Users.js" Step 3's Create call.
+   *
+   * MustChangePassword is sent as false here too, but SFMC's Create call
+   * does not reliably honor it — this is exactly why the original
+   * automation needed a *separate* Update call afterward
+   * (see updateUserMustChangePasswordFalse below). Create still assigns
+   * the BU, role, and initial password.
+   */
+  async createUser({ userId, password, name, email, authMID, targetMID, roleID }) {
+    const body =
+      '<CreateRequest xmlns="http://exacttarget.com/wsdl/partnerAPI">' +
+      '<Objects xsi:type="AccountUser">' +
+      `<Client><ID>${authMID}</ID></Client>` +
+      `<UserID>${escapeXml(userId)}</UserID>` +
+      `<Password>${escapeXml(password)}</Password>` +
+      `<Name>${escapeXml(name)}</Name>` +
+      `<Email>${escapeXml(email)}</Email>` +
+      `<NotificationEmailAddress>${escapeXml(email)}</NotificationEmailAddress>` +
+      "<ActiveFlag>true</ActiveFlag>" +
+      "<MustChangePassword>false</MustChangePassword>" +
+      `<DefaultBusinessUnit>${targetMID}</DefaultBusinessUnit>` +
+      "<AssociatedBusinessUnits>" +
+      `<BusinessUnit><ID>${targetMID}</ID></BusinessUnit>` +
+      "</AssociatedBusinessUnits>" +
+      `<Roles><Role><ObjectID>${escapeXml(roleID)}</ObjectID></Role></Roles>` +
+      "</Objects>" +
+      "</CreateRequest>";
+
+    const raw = await this._soapRequest("Create", body);
+    return parseCreateOrUpdateResult(raw);
+  }
+
+  /**
+   * Update an existing AccountUser so the password is not required to be
+   * changed again ("password never expires" in Setup UI terms). This is
+   * the second call in the required create-then-update sequence — Mirrors
+   * "2.2 Update Student Users.js".
+   */
+  async updateUserMustChangePasswordFalse({ userId, authMID }) {
+    const body =
+      '<UpdateRequest xmlns="http://exacttarget.com/wsdl/partnerAPI">' +
+      '<Objects xsi:type="AccountUser">' +
+      `<Client><ID>${authMID}</ID></Client>` +
+      `<UserID>${escapeXml(userId)}</UserID>` +
+      "<MustChangePassword>false</MustChangePassword>" +
+      "</Objects>" +
+      "</UpdateRequest>";
+
+    const raw = await this._soapRequest("Update", body);
+    return parseCreateOrUpdateResult(raw);
+  }
+
   /** Clear all rows from a Data Extension (replaces WSProxy ClearData). */
   async clearDataExtension(deKey) {
     const body =


### PR DESCRIPTION
## Summary
- New `workflow_dispatch` workflow (`create-users.yml`) mirrors the old `2.1 Create Student Users` / `2.2 Update Student Users` CloudPage scripts.
- Team supplies only the target **Business Unit MID** and a **user list** (one `username,Full Name` per line, comma or tab separated — pastes straight from a spreadsheet).
- Password, Role ID, shared user email, and the required create-then-update `MustChangePassword=false` sequencing are all hardcoded via repo Secrets/Variables, per the same pattern as the existing `create-business-unit.yml` workflow.
- Password is stored as a repo **Secret** (`DEFAULT_USER_PASSWORD`), not committed in plaintext, so it's never shown in the workflow form or visible in git history.
- Added `createUser()` and `updateUserMustChangePasswordFalse()` to `scripts/sfmc-client.js`, and a new `scripts/create-users.js` entry point (`npm run create-users`).
- Extended README with full setup docs (new Secrets/Variables needed, run instructions, format example).

## Test plan
- [ ] Add the new Secrets (`DEFAULT_USER_PASSWORD`) and Variables (`DEFAULT_USER_ROLE_ID`, `DEFAULT_USER_EMAIL`, `LOG_DE_KEY_CREATE_USERS`) in repo settings.
- [ ] Run the workflow with a test BU MID and 1–2 test usernames; confirm both users are created and both show `MustChangePassword=false` in Setup afterward.
- [ ] Confirm rows appear in `Automation_Log_CreateVIWStudent` for each user.
- [ ] Confirm the job summary table renders per-user Create/Update status correctly, including a deliberately-bad username to check failure handling.